### PR TITLE
Improve docker detection in create_pmtiles.sh

### DIFF
--- a/scripts/create_pmtiles.sh
+++ b/scripts/create_pmtiles.sh
@@ -13,12 +13,24 @@ FILENAME="at-plus.pmtiles"
 DOCKER_IMAGE="ghcr.io/onthegomap/planetiler:latest"
 DEBUG_LOG="/srv/scripts/planetiler_raw_debug.log"
 USE_SUDO="${USE_SUDO:-0}"
+DOCKER_BIN=""
 
 # --- VORBEREITUNG ---
 export STATS_DIR="$STATS_DIR"
 
-if ! command -v docker >/dev/null 2>&1; then
-    echo "❌ FEHLER: 'docker' Kommando nicht gefunden. Bitte Docker installieren (z.B. docker.io)."
+DOCKER_BIN="$(command -v docker 2>/dev/null || true)"
+if [ -z "$DOCKER_BIN" ]; then
+    for candidate in /usr/bin/docker /usr/local/bin/docker /bin/docker; do
+        if [ -x "$candidate" ]; then
+            DOCKER_BIN="$candidate"
+            break
+        fi
+    done
+fi
+if [ -z "$DOCKER_BIN" ]; then
+    echo "❌ FEHLER: 'docker' Kommando nicht gefunden."
+    echo "Bitte Docker installieren (z.B. docker.io) und sicherstellen, dass der Pfad (PATH) korrekt ist."
+    echo "Aktueller PATH: $PATH"
     exit 1
 fi
 if ! systemctl is-active --quiet docker; then echo "❌ FEHLER: Docker läuft nicht."; exit 1; fi
@@ -37,7 +49,7 @@ echo "Starte Docker im Hintergrund..."
 
 # WICHTIG: Docker läuft im Hintergrund (&) und schreibt in die Datei.
 # Python läuft im Vordergrund und liest die Datei. Keine Pipe, kein Deadlock.
-DOCKER_CMD="docker"
+DOCKER_CMD="$DOCKER_BIN"
 if [ "$USE_SUDO" -eq 1 ]; then
     DOCKER_CMD="sudo docker"
 fi


### PR DESCRIPTION
### Motivation
- Ensure the `create_pmtiles.sh` script reliably locates the Docker binary when `docker` is not found on `PATH` or is installed in a common non-PATH location.
- Make the error output more helpful when Docker is missing by reporting the current `PATH` to aid debugging.
- Use the resolved Docker binary consistently when starting the Planetiler container so the chosen binary is executed.

### Description
- Add a `DOCKER_BIN` variable and resolve it with `command -v docker` and fallbacks for `/usr/bin/docker`, `/usr/local/bin/docker`, and `/bin/docker`.
- Fail with a clearer error message that recommends installing Docker and prints `PATH` when no binary is found.
- Replace the literal `docker` invocation by setting `DOCKER_CMD` to the resolved `DOCKER_BIN` so the script runs the discovered binary.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bf46987a8832b934f2e2c814af930)