### PR TITLE
Install `docker-cli` and improve Docker detection/usage in `create_pmtiles.sh`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ fi
 # 1. Abhängigkeiten prüfen/installieren
 echo "[1] Installiere System-Pakete..."
 sudo apt-get update
-sudo apt-get install -y osmium-tool wget python3 docker.io acl
+sudo apt-get install -y osmium-tool wget python3 docker.io docker-cli acl
 
 # 2. Ordnerstruktur erstellen
 echo "[2] Erstelle Ordnerstruktur in /srv..."

--- a/scripts/create_pmtiles.sh
+++ b/scripts/create_pmtiles.sh
@@ -13,12 +13,24 @@ FILENAME="at-plus.pmtiles"
 DOCKER_IMAGE="ghcr.io/onthegomap/planetiler:latest"
 DEBUG_LOG="/srv/scripts/planetiler_raw_debug.log"
 USE_SUDO="${USE_SUDO:-0}"
+DOCKER_BIN=""
 
 # --- VORBEREITUNG ---
 export STATS_DIR="$STATS_DIR"
 
-if ! command -v docker >/dev/null 2>&1; then
-    echo "❌ FEHLER: 'docker' Kommando nicht gefunden. Bitte Docker installieren (z.B. docker.io)."
+DOCKER_BIN="$(command -v docker 2>/dev/null || true)"
+if [ -z "$DOCKER_BIN" ]; then
+    for candidate in /usr/bin/docker /usr/local/bin/docker /bin/docker; do
+        if [ -x "$candidate" ]; then
+            DOCKER_BIN="$candidate"
+            break
+        fi
+    done
+fi
+if [ -z "$DOCKER_BIN" ]; then
+    echo "❌ FEHLER: 'docker' Kommando nicht gefunden."
+    echo "Bitte Docker installieren (z.B. docker.io) und sicherstellen, dass der Pfad (PATH) korrekt ist."
+    echo "Aktueller PATH: $PATH"
     exit 1
 fi
 if ! systemctl is-active --quiet docker; then echo "❌ FEHLER: Docker läuft nicht."; exit 1; fi
@@ -37,7 +49,7 @@ echo "Starte Docker im Hintergrund..."
 
 # WICHTIG: Docker läuft im Hintergrund (&) und schreibt in die Datei.
 # Python läuft im Vordergrund und liest die Datei. Keine Pipe, kein Deadlock.
-DOCKER_CMD="docker"
+DOCKER_CMD="$DOCKER_BIN"
 if [ "$USE_SUDO" -eq 1 ]; then
     DOCKER_CMD="sudo docker"
 fi


### PR DESCRIPTION
### Motivation
- Ensure the `docker` command is available on Debian 13 by installing `docker-cli` alongside `docker.io`.
- Make `create_pmtiles.sh` reliably locate the Docker binary when `docker` is not found on `PATH` or is installed in common non-PATH locations.
- Provide clearer error output and use the resolved Docker binary consistently when starting the Planetiler container.

### Description
- Add `docker-cli` to the `apt-get install` list in `install.sh` so the `docker` CLI is present on Debian systems where it is packaged separately from `docker.io`.
- Add `DOCKER_BIN` resolution in `scripts/create_pmtiles.sh` using ``command -v`` with fallbacks for `/usr/bin/docker`, `/usr/local/bin/docker`, and `/bin/docker`.
- Improve error messaging to print the current `PATH` when no Docker binary is found and fail early if Docker is not running or input files are missing.
- Replace hardcoded `docker` usage with a `DOCKER_CMD` variable (set to the resolved `DOCKER_BIN` and respecting `USE_SUDO`) so the discovered binary is executed.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bf46987a8832b934f2e2c814af930)