### PR TITLE
Add README and document OSM pipeline (include Docker install/usage fixes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Geodata Updater
+
+Dieses Repository enthält Skripte für eine OSM-Geodata-Pipeline:
+
+- Download von Geofabrik-PBFs
+- Merge zu einer Gesamtdatei
+- Generierung von PMTiles via Planetiler (Docker)
+
+## Installation
+
+```bash
+./install.sh
+```
+
+Hinweis: Auf Debian 13.x ist das Docker-CLI in einem separaten Paket (`docker-cli`).
+Das Installationsskript installiert daher sowohl `docker.io` als auch `docker-cli`.
+
+## Nutzung
+
+```bash
+/srv/scripts/update_map.sh
+```
+
+Logs werden standardmäßig in `/var/log/osm_update.log` geschrieben (oder nach
+`/srv/scripts/osm_update.log`, falls das Standardziel nicht beschreibbar ist).
+
+## Voraussetzungen
+
+- Linux mit `apt`
+- Docker-Daemon laufend
+
+## Verzeichnisse
+
+- Skripte: `/srv/scripts`
+- OSM Daten: `/srv/osm`
+- PMTiles: `/srv/pmtiles`

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ fi
 # 1. Abhängigkeiten prüfen/installieren
 echo "[1] Installiere System-Pakete..."
 sudo apt-get update
-sudo apt-get install -y osmium-tool wget python3 docker.io acl
+sudo apt-get install -y osmium-tool wget python3 docker.io docker-cli acl
 
 # 2. Ordnerstruktur erstellen
 echo "[2] Erstelle Ordnerstruktur in /srv..."

--- a/scripts/create_pmtiles.sh
+++ b/scripts/create_pmtiles.sh
@@ -13,12 +13,24 @@ FILENAME="at-plus.pmtiles"
 DOCKER_IMAGE="ghcr.io/onthegomap/planetiler:latest"
 DEBUG_LOG="/srv/scripts/planetiler_raw_debug.log"
 USE_SUDO="${USE_SUDO:-0}"
+DOCKER_BIN=""
 
 # --- VORBEREITUNG ---
 export STATS_DIR="$STATS_DIR"
 
-if ! command -v docker >/dev/null 2>&1; then
-    echo "❌ FEHLER: 'docker' Kommando nicht gefunden. Bitte Docker installieren (z.B. docker.io)."
+DOCKER_BIN="$(command -v docker 2>/dev/null || true)"
+if [ -z "$DOCKER_BIN" ]; then
+    for candidate in /usr/bin/docker /usr/local/bin/docker /bin/docker; do
+        if [ -x "$candidate" ]; then
+            DOCKER_BIN="$candidate"
+            break
+        fi
+    done
+fi
+if [ -z "$DOCKER_BIN" ]; then
+    echo "❌ FEHLER: 'docker' Kommando nicht gefunden."
+    echo "Bitte Docker installieren (z.B. docker.io) und sicherstellen, dass der Pfad (PATH) korrekt ist."
+    echo "Aktueller PATH: $PATH"
     exit 1
 fi
 if ! systemctl is-active --quiet docker; then echo "❌ FEHLER: Docker läuft nicht."; exit 1; fi
@@ -37,7 +49,7 @@ echo "Starte Docker im Hintergrund..."
 
 # WICHTIG: Docker läuft im Hintergrund (&) und schreibt in die Datei.
 # Python läuft im Vordergrund und liest die Datei. Keine Pipe, kein Deadlock.
-DOCKER_CMD="docker"
+DOCKER_CMD="$DOCKER_BIN"
 if [ "$USE_SUDO" -eq 1 ]; then
     DOCKER_CMD="sudo docker"
 fi


### PR DESCRIPTION
### Motivation
- Provide a top-level `README.md` that documents the OSM Geodata pipeline, installation, usage, prerequisites, and directory layout.
- Explain the special-case Docker packaging on Debian 13 (separate `docker-cli` package).
- Improve robustness of Docker usage in the pipeline by ensuring the CLI is installed and the `create_pmtiles.sh` script can find a Docker binary.

### Description
- Add `README.md` with installation steps, usage examples, prerequisites, and directory structure for the pipeline.
- Update `install.sh` to install `docker-cli` in addition to `docker.io` via `apt-get install` to cover Debian 13 packaging.
- Update `scripts/create_pmtiles.sh` to resolve `DOCKER_BIN` using `command -v` with fallbacks (`/usr/bin/docker`, `/usr/local/bin/docker`, `/bin/docker`) and emit clearer error messages including the current `PATH` when Docker is missing.
- Use a `DOCKER_CMD` variable (set from `DOCKER_BIN` and honoring `USE_SUDO`) so the discovered Docker binary is invoked consistently.

### Testing
- No automated tests were run.
- Manual validation: README file added and committed to repository (no runtime checks performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bf46987a8832b934f2e2c814af930)